### PR TITLE
Add example of LangChain with Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # ChatGPTWithGitHub
+
+This repository contains a minimal example showing how to use [LangChain](https://python.langchain.com/) with an [Ollama](https://ollama.ai/) model.
+
+## Requirements
+
+- Python 3.8+
+- `langchain` and `ollama` Python packages
+- An Ollama server with a model installed (for example `llama2`)
+
+## Running the example
+
+1. Install the dependencies:
+
+```bash
+pip install langchain ollama
+```
+
+2. Ensure the Ollama server is running and the model specified in `langchain_ollama_example.py` is available.
+
+3. Execute the script:
+
+```bash
+python langchain_ollama_example.py
+```
+
+The script sends a prompt to the model asking it to translate a short text into French. The response from Ollama will be printed to the console.

--- a/langchain_ollama_example.py
+++ b/langchain_ollama_example.py
@@ -1,0 +1,21 @@
+from langchain import PromptTemplate, LLMChain
+from langchain.llms import Ollama
+
+
+def main():
+    """Run a simple LangChain example using an Ollama model."""
+    prompt = PromptTemplate(
+        template="Translate the following text to {language}: {text}",
+        input_variables=["language", "text"],
+    )
+
+    # Replace 'llama2' with the name of an Ollama model you have installed
+    llm = Ollama(model="llama2")
+    chain = LLMChain(prompt=prompt, llm=llm)
+
+    result = chain.run({"language": "French", "text": "Hello, my friend!"})
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+langchain
+ollama


### PR DESCRIPTION
## Summary
- add README instructions describing how to run a LangChain Ollama example
- create `langchain_ollama_example.py` showing LangChain usage
- specify required packages in `requirements.txt`

## Testing
- `python langchain_ollama_example.py` *(fails: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_b_684bb6eb738c832bb03d35a9c0ecee80